### PR TITLE
WIP: Attempt to bring in import/no-cycle rule to detect import cycles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
+    "plugin:import/typescript",
     "prettier"
   ],
   "plugins": [
@@ -76,6 +77,12 @@
         "pathGroupsExcludedImportTypes": [
           "type"
         ]
+      }
+    ],
+    "import/no-cycle": [
+      "error",
+      {
+        "ignoreExternal": true
       }
     ],
     "@typescript-eslint/no-namespace": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@matrixai/typescript-demo-lib-native",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --strip --target=16.14.2",
     "build": "rimraf ./dist && tsc -p ./tsconfig.build.json",
+    "postversion": "npm install --package-lock-only --ignore-scripts --silent",
     "ts-node": "ts-node -r tsconfig-paths/register",
     "test": "jest",
     "lint": "eslint '{src,tests}/**/*.{js,ts}'",

--- a/src/lib/Library.ts
+++ b/src/lib/Library.ts
@@ -1,8 +1,12 @@
+import NumPair from './NumPair';
+
 class Library {
   someParam: string;
+  num: NumPair;
 
   constructor(someParam = 'Parameter') {
     this.someParam = someParam;
+    this.num = new NumPair();
   }
 }
 

--- a/src/lib/NumPair.ts
+++ b/src/lib/NumPair.ts
@@ -1,10 +1,14 @@
+import Library from './Library';
+
 class NumPair {
   num1: number;
   num2: number;
+  lib: Library;
 
   constructor(firstNum = 0, secondNum = 0) {
     this.num1 = firstNum;
     this.num2 = secondNum;
+    this.lib = new Library();
   }
 }
 


### PR DESCRIPTION
### Description

Import cycles are a problem in PK. This seems to help detect it. I'm still evaluating it's safety and robustness.

### Tasks

- [ ] 1. Check if we are missing a dependency https://github.com/alexgorbatchev/eslint-import-resolver-typescript/issues/106
- [ ] 2. Try out different kinds of import cycles
- [ ] 3. Identify where we have legal import cycles and how to disable the rule like in our `src/errors.ts` in js-polykey

### Final checklist

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
